### PR TITLE
Updated part.cfg

### DIFF
--- a/Release/AirplanePlus/Parts/Payload/Mk1DroneDoor/part.cfg
+++ b/Release/AirplanePlus/Parts/Payload/Mk1DroneDoor/part.cfg
@@ -32,7 +32,7 @@ PART
 	breakingTorque = 50
 	maxTemp = 2000 // = 3000
 	fuelCrossFeed = True
-	bulkheadProfiles = size1, srf
+	bulkheadProfiles = size1
 	tags = aircraft airplane equipment freight hold jet mk1 plane payload
 
 	MODULE
@@ -52,10 +52,8 @@ PART
 		name = ModuleCargoBay
 		DeployModuleIndex = 0
 		closedPosition = 1
-		lookupRadius = 1.5
-		
-		nodeOuterAftID = top
-		nodeInnerAftID = top2
+		lookupCenter = 0,1.875,0
+		lookupRadius = 2
 	}
 MODULE
 {


### PR DESCRIPTION
- Removed 'srf' bulheadprofile as this part has surface attach disabled;
- Offset the center of the lookupRadius into the bay itself to be able to cast rays from it;
- Increased the radius to cover the interior better. (Before: 1.5);
- Removed the nodeOuterAftID and nodeInnerAftID since this part has no open end;