### PR TITLE
Fixes for bulkheadProfiles & ModuleCargoBay

### DIFF
--- a/Release/AirplanePlus/Parts/Payload/PassengerDoor/part.cfg
+++ b/Release/AirplanePlus/Parts/Payload/PassengerDoor/part.cfg
@@ -34,7 +34,7 @@ PART
 	breakingTorque = 50
 	maxTemp = 2000 // = 3000
 	fuelCrossFeed = True
-	bulkheadProfiles = size1, srf
+	bulkheadProfiles = size1
 	tags = aircraft airplane equipment freight hold hollow jet mk1 pipe plane tube payload
 	
 	DRAG_CUBE
@@ -55,17 +55,15 @@ PART
 		revClampSpeed = true	
 		revClampPercent = true			
 	}
-	//MODULE
+	MODULE
 	{
 		name = ModuleCargoBay
 		DeployModuleIndex = 0
 		closedPosition = 1
-		lookupRadius = 1.5
+		lookupRadius = 0.8
 		
 		nodeOuterForeID = top
 		nodeOuterAftID = bottom
-		nodeInnerForeID = top2
-		nodeInnerAftID = bottom2
 	}
 //MODULE
 {


### PR DESCRIPTION
- Removed 'srf' bulkheadprofile as this part has surface attach mode disabled in its attachRules;
- Uncommented ModuleCargoBay;
- Tweaked the lookupRadius to better cover the part interior (Was 1.5);
- Removed the nodeInner*ID's as there is no need for them here;
Note: Purposefully did not touch the typo in the part name to maintain compatibility with previous versions.