### PR TITLE
Fixing the bulkhead profile on some S2 parts

### DIFF
--- a/Release/AirplanePlus/Parts/Structure and Fuel/size2parts/size2tank.cfg
+++ b/Release/AirplanePlus/Parts/Structure and Fuel/size2parts/size2tank.cfg
@@ -32,7 +32,7 @@ PART
 	maxTemp = 2000 // = 3000
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
-	bulkheadProfiles = srf, size1
+	bulkheadProfiles = srf, size2
 	
 	RESOURCE
 	{

--- a/Release/AirplanePlus/Parts/Structure and Fuel/size2parts/size2under.cfg
+++ b/Release/AirplanePlus/Parts/Structure and Fuel/size2parts/size2under.cfg
@@ -30,7 +30,7 @@ PART
 	maxTemp = 2000 // = 3000
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
-	bulkheadProfiles = srf, size1
+	bulkheadProfiles = srf, size2
 	
 	RESOURCE
 	{


### PR DESCRIPTION
Hi.

I'm writing TweakScale support for AirplanePlus, and so ended up reviewing some info on the A+ parts and realised there're two S2 parts with the `bulkheadProfile` set to size1.

Not big deal, this would affect only the part filtering on the Parts Palette, but since some [automated tools are seeing the limelight](https://github.com/OnlyLightMatters/TS-Restockplus) recently, keeping the parts accurate will be of great value: it will allow us to automate some harsh tasks while maintaining the patches as time goes by!

Cheers.